### PR TITLE
explicitly define box-sizing for container and it contents

### DIFF
--- a/demo/css/jquery.cropzoom.css
+++ b/demo/css/jquery.cropzoom.css
@@ -33,4 +33,6 @@
 .mvn_e:hover{background-position:100% -84px;}
 .mvn_so:hover{background-position:100% -105px;}
 .mvn_s:hover{background-position:100% -126px;}
-.mvn_se:hover{background-position:100% -147px;} 
+.mvn_se:hover{background-position:100% -147px;}
+
+.cropzoom-container,.cropzoom-container div{box-sizing: content-box;}

--- a/plugin/jquery.cropzoom.js
+++ b/plugin/jquery.cropzoom.js
@@ -106,6 +106,7 @@
                     'position': 'relative',
                     'border': '2px solid #333'
                 });
+                _self.addClass('cropzoom-container');
 
                 setData('image', {
                     h: $options.image.height,


### PR DESCRIPTION
current widget code does not take into account default `box-sizing` style.
Also jQuery UI has a bug with `box-sizing`: http://bugs.jqueryui.com/ticket/8932
This PR force default `content-box` to all div elements inside widget container.
